### PR TITLE
Cuda 8 now required for latest Docker Caffe

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:7.5-cudnn4-devel
+FROM nvidia/cuda:8.0-cudnn5-devel
 
 MAINTAINER Sai Soundararaj <saip@outlook.com>
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ If you are not familiar with Docker, but would still like an all-in-one solution
 ## Specs
 This is what you get out of the box when you create a container with the provided image/Dockerfile:
 * Ubuntu 14.04
-* [CUDA 7.5](https://developer.nvidia.com/cuda-toolkit) (GPU version only)
-* [cuDNN v4](https://developer.nvidia.com/cudnn) (GPU version only)
+* [CUDA 8.0](https://developer.nvidia.com/cuda-toolkit) (GPU version only)
+* [cuDNN v5](https://developer.nvidia.com/cudnn) (GPU version only)
 * [Tensorflow](https://www.tensorflow.org/)
 * [Caffe](http://caffe.berkeleyvision.org/)
 * [Theano](http://deeplearning.net/software/theano/)


### PR DESCRIPTION
All built for me fine, but might be reasons for staying with 7.5?