### PR TITLE
fix bug: Tornado requires an up-to-date SSL module. This means Python…

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -101,7 +101,7 @@ RUN apt-get update && apt-get install -y \
 		doxygen \
 		&& \
 	apt-get clean && \
-	apt-get autoremove && \
+	apt-get -y autoremove && \
 	rm -rf /var/lib/apt/lists/* && \
 # Link BLAS library to use OpenBLAS using the alternatives mechanism (https://www.scipy.org/scipylib/building/linux.html#debian-ubuntu)
 	update-alternatives --set libblas.so.3 /usr/lib/openblas-base/libblas.so.3
@@ -131,10 +131,11 @@ RUN apt-get update && apt-get install -y \
 		python-sympy \
 		&& \
 	apt-get clean && \
-	apt-get autoremove && \
+	apt-get -y autoremove && \
 	rm -rf /var/lib/apt/lists/*
 
 # Install other useful Python packages using pip
+RUN apt-get -y remove ipython
 RUN pip --no-cache-dir install --upgrade ipython && \
 	pip --no-cache-dir install \
 		Cython \
@@ -170,7 +171,7 @@ RUN apt-get update && apt-get install -y \
 		protobuf-compiler \
 		&& \
 	apt-get clean && \
-	apt-get autoremove && \
+	apt-get -y autoremove && \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Caffe

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -10,6 +10,31 @@ ARG LASAGNE_VERSION=v0.1
 ARG TORCH_VERSION=latest
 ARG CAFFE_VERSION=master
 
+ARG PYTHON_BASEDEPS="build-essential python-pip"
+ARG PYTHON_BUILDDEPS="libbz2-dev 
+libc6-dev 
+libgdbm-dev 
+libncursesw5-dev 
+libreadline-gplv2-dev 
+libsqlite3-dev 
+libssl-dev 
+tk-dev"
+
+ARG PYTHON_TARFILE="Python-2.7.9.tgz"
+ARG PYTHON_TARHOST="https://www.python.org/ftp/python/2.7.9"
+ARG PYTHON_SRCDIR="Python-2.7.9"
+
+RUN apt-get update
+RUN apt-get install -y ${PYTHON_BASEDEPS} ${PYTHON_BUILDDEPS}
+
+RUN wget "${PYTHON_TARHOST}/${PYTHON_TARFILE}"
+RUN tar xvf ${PYTHON_TARFILE}
+
+RUN cd ${PYTHON_SRCDIR} && 
+./configure && 
+make && 
+make install
+
 # Install some dependencies
 RUN apt-get update && apt-get install -y \
 		bc \


### PR DESCRIPTION
… 2.7.9+ or 3.4+ (although some distributions have backported the necessary changes to older versions).